### PR TITLE
Added requirement 5 - precedence

### DIFF
--- a/PriceCalculatorKata/PriceWithDiscount.cs
+++ b/PriceCalculatorKata/PriceWithDiscount.cs
@@ -10,7 +10,18 @@ namespace PriceCalculatorKata
     {
         public static decimal DiscountAmount(Product product)
         {
-            return Discount.HasDiscount ? Math.Round((product.Price * Discount.DiscountPercentage), 2) : 0;
+            decimal discountAmount;
+            if (UPCDiscount.BeforeTax)
+            {
+                discountAmount= Discount.HasDiscount ? Math.Round((PriceWithUPCDiscount.PriceAfterUPCDiscount(product) * Discount.DiscountPercentage), 2) : 0;
+
+            }
+            else
+            {
+                discountAmount = Discount.HasDiscount ? Math.Round((product.Price * Discount.DiscountPercentage), 2) : 0;
+
+            }
+            return discountAmount;
         }
 
         public static decimal PriceAfterDiscount(Product product)

--- a/PriceCalculatorKata/PriceWithTax.cs
+++ b/PriceCalculatorKata/PriceWithTax.cs
@@ -11,6 +11,12 @@ namespace PriceCalculatorKata
 
         public static decimal TaxAmount(Product product)
         {
+            if (UPCDiscount.BeforeTax)
+            {
+                return Math.Round((PriceWithUPCDiscount.PriceAfterUPCDiscount(product) * Tax.TaxPercentage), 2);
+                
+            }
+            else
             return Math.Round((product.Price * Tax.TaxPercentage),2);
         }
 

--- a/PriceCalculatorKata/PriceWithTaxAndDiscount.cs
+++ b/PriceCalculatorKata/PriceWithTaxAndDiscount.cs
@@ -10,10 +10,10 @@ namespace PriceCalculatorKata
     {
         public static decimal FinalPrice(Product product)
         {
-            decimal priceAfterDiscount = PriceWithDiscount.PriceAfterDiscount(product);
+            decimal discountAmount = PriceWithDiscount.DiscountAmount(product);
             decimal taxAmount = PriceWithTax.TaxAmount(product);
             decimal UPCDiscountAmount = PriceWithUPCDiscount.DiscountAmount(product);
-            return Math.Round(priceAfterDiscount - UPCDiscountAmount + taxAmount , 2);
+            return Math.Round(product.Price - discountAmount - UPCDiscountAmount + taxAmount, 2);
         }
     }
 }

--- a/PriceCalculatorKata/Print.cs
+++ b/PriceCalculatorKata/Print.cs
@@ -89,15 +89,22 @@ namespace PriceCalculatorKata
         public static void PrintUPCDiscountAmount(Product product)
         {
             if(UPCDiscount.HasUPCDiscount(product))
-            Console.WriteLine("UPC Discount Amount: " + PriceWithUPCDiscount.DiscountAmount(product));
+            Console.Write("UPC Discount Amount: " + PriceWithUPCDiscount.DiscountAmount(product));
+            if (UPCDiscount.BeforeTax)
+            {
+                Console.WriteLine(" Before Tax");
+            }
 
         }
 
         public static void PrintUPCDiscountPercentage(Product product)
         {
             if (UPCDiscount.HasUPCDiscount(product))
-                Console.WriteLine("UPC Discount Percentage: " + UPCDiscount.UPCDiscountPercentage(product));
-
+                Console.Write("UPC Discount Percentage: " + UPCDiscount.UPCDiscountPercentage(product));
+            if (UPCDiscount.BeforeTax)
+            {
+                Console.WriteLine(" Before Tax");
+            }
         }
     }
 }

--- a/PriceCalculatorKata/Test.cs
+++ b/PriceCalculatorKata/Test.cs
@@ -9,6 +9,7 @@ namespace PriceCalculatorKata
             UserInterface.SetHasDiscount(true);
             UserInterface.SetDiscountByCustomer();
             UserInterface.AddUPCDiscount(12345, 0.07m);
+            UserInterface.SetBeforeTaxDiscount(true);
 
             Product product1 = new()
             {
@@ -18,15 +19,6 @@ namespace PriceCalculatorKata
             };
             Print.PrintAllInfo(product1);
 
-
-            UserInterface.SetHasDiscount(false);
-            Product product2 = new()
-            {
-                Name = "The Little Prince",
-                UPC = 12345,
-                Price = 20.25m
-            };
-            Print.PrintAllInfo(product2);
 
         }
     }

--- a/PriceCalculatorKata/UPCDiscount.cs
+++ b/PriceCalculatorKata/UPCDiscount.cs
@@ -9,7 +9,7 @@ namespace PriceCalculatorKata
     public class UPCDiscount
     {
         public static Dictionary<int, decimal>? UPCDiscountList = new();
-
+        public static bool BeforeTax = false;
 
         public static decimal UPCDiscountPercentage(Product product)
         {

--- a/PriceCalculatorKata/UserInterface.cs
+++ b/PriceCalculatorKata/UserInterface.cs
@@ -36,5 +36,10 @@ namespace PriceCalculatorKata
 
             UPCDiscount.UPCDiscountList.Add(UPC, discountPercentage);
         }
+
+        public static void SetBeforeTaxDiscount(bool beforeTax)
+        {
+            UPCDiscount.BeforeTax = beforeTax;
+        }
     }
 }


### PR DESCRIPTION
Hello again,
I pushed requirement 5, which says that UPC Discount is applied on base price, but Tax and Universal discount is applied on price after UPC discount . 
Note: I understood that if "before Tax" is true --> all UPC Discount will applied before tax (it's not for a specific UPC), this is right ?

